### PR TITLE
Use node 14 in github action

### DIFF
--- a/.github/workflows/plone-package.yml
+++ b/.github/workflows/plone-package.yml
@@ -15,6 +15,10 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 14
+                  cache: 'npm'
             - uses: actions/cache@v2
               with:
                   path: |


### PR DESCRIPTION
The currently used version of node-sass (^4.9.0) does not support node > 14.

The error occurs:

```bash
  make: *** [binding.target.mk:133: Release/obj.target/binding/src/binding.o] Error 1
  make: Leaving directory '/tmp/tmpDrRkeK/webpack/node_modules/node-sass/build'
  gyp ERR! build error 
  gyp ERR! stack Error: `make` failed with exit code: 2
  gyp ERR! stack     at ChildProcess.onExit (/tmp/tmpDrRkeK/webpack/node_modules/node-gyp/lib/build.js:262:23)
  gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
  gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
  gyp ERR! System Linux 5.15.0-1034-azure
  gyp ERR! command "/usr/local/bin/node" "/tmp/tmpDrRkeK/webpack/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
  gyp ERR! cwd /tmp/tmpDrRkeK/webpack/node_modules/node-sass
  gyp ERR! node -v v18.15.0
  gyp ERR! node-gyp -v v3.8.0
  gyp ERR! not ok 
  Build failed with error code: 1
```